### PR TITLE
🐛 컬러 수정

### DIFF
--- a/src/components/globals/Rank.tsx
+++ b/src/components/globals/Rank.tsx
@@ -56,7 +56,7 @@ const RankInfo = ({ now, last }: RankProps) => {
 const Rank = ({ now, last }: RankProps) => {
   return (
     <Container>
-      <T4Bold>{now}</T4Bold>
+      <T4Bold color={colors.gray900}>{now}</T4Bold>
       <Info>
         <RankInfo now={now} last={last} />
       </Info>

--- a/src/components/index/Chart.tsx
+++ b/src/components/index/Chart.tsx
@@ -21,7 +21,7 @@ const Chart = ({}: ChartProps) => {
     <Container>
       <Header>
         <HeaderTexts>
-          <Title>왁뮤차트 TOP100</Title>
+          <Title color={colors.primary900}>왁뮤차트 TOP100</Title>
           <UpdatedContainer>
             <CheckSVG />
             <T7Light>

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -13,6 +13,8 @@ const colors: { [color: string]: string } = {
   blueGray500: "#667085",
   blueGray600: "#475467",
 
+  primary900: "#101828",
+
   white: "#FFFFFF",
   yellow: "#FF8F0C",
   point: "#08DEF7",

--- a/src/pages/index/Index.tsx
+++ b/src/pages/index/Index.tsx
@@ -6,6 +6,7 @@ import Background from "@components/index/Background";
 import Chart from "@components/index/Chart";
 import RecommandItem from "@components/index/RecommandItem";
 
+import colors from "@constants/colors";
 import { recommended } from "@constants/dummys";
 
 interface IndexProps {}
@@ -18,7 +19,7 @@ const Index = ({}: IndexProps) => {
       <Chart />
 
       <RecommandContainer>
-        <T4Medium>왁뮤팀이 추천하는 리스트</T4Medium>
+        <T4Medium color={colors.primary900}>왁뮤팀이 추천하는 리스트</T4Medium>
         <RecommandItems>
           {recommended.map((item, index) => (
             <RecommandItem key={index} item={item} />


### PR DESCRIPTION
## 개요

검정색같지만 검정색이 아닌 텍스트들의 색깔 수정

## 이슈

#32 

## 작업 내용

- primary900 (#101828) 컬러 추가
- index 페이지의 텍스트 2개 컬러 수정
- Rank 컴포넌트의 랭크 숫자 컬러 수정

## 스크린샷

![image](https://github.com/wakmusic/wakmusic-pc/assets/61264156/5b36cbc4-b7a5-4d60-b3ce-bab78db6b9d2)
