### PR TITLE
🐛 분리모드 체크 시스템 버그 해결

### DIFF
--- a/src/electron.ts
+++ b/src/electron.ts
@@ -124,7 +124,7 @@ ipcMain.on("query:isSeparate", () => {
 
   const bounds = win.getBounds();
 
-  ipcMain.emit("reply:isSeparate", bounds.width === 290);
+  win.webContents.send("reply:isSeparate", bounds.width === 290);
 });
 
 ipcMain.on("rpc:progress", (_event, progress: number) => {


### PR DESCRIPTION
## 개요

분리모드 체크 시스템 버그 해결 (분리모드에서 비정상적인 방법으로 벗어나지 못하도록 / 일반모드에서 `/player`로 들어갈 수 없도록)

## 작업 내용

- 메인 프로세스에서 `win.webContents.send`로 데이터를 전달하도록 수정
