### PR TITLE
🐛 아티스트 이미지가 안떠도 UI는 꺠지지 않게

### DIFF
--- a/src/animations/artist.ts
+++ b/src/animations/artist.ts
@@ -5,6 +5,11 @@ export const containerVariants: Variants = {
   round: { height: 93 },
 };
 
+export const artistImageVariants: Variants = {
+  square: { width: 140 },
+  round: { width: 68 },
+};
+
 export const backgroundVariants: Variants = {
   square: { width: 140, height: 180, borderRadius: 8, y: 0 },
   round: { width: 68, height: 68, borderRadius: 100, y: 4 },

--- a/src/components/artists/ArtistImage.tsx
+++ b/src/components/artists/ArtistImage.tsx
@@ -1,5 +1,9 @@
 import { AnimationControls, motion } from "framer-motion";
-import { backgroundVariants, characterVariants } from "src/animations/artist";
+import {
+  artistImageVariants,
+  backgroundVariants,
+  characterVariants,
+} from "src/animations/artist";
 import styled, { css } from "styled-components/macro";
 
 import { Artist } from "@templates/artists";
@@ -14,7 +18,11 @@ interface ArtistImageProps {
 
 const ArtistImage = ({ artist, controls }: ArtistImageProps) => {
   return (
-    <Container>
+    <Container
+      animate={controls}
+      initial="square"
+      variants={artistImageVariants}
+    >
       <Background
         $color={artist.color.card}
         animate={controls}
@@ -33,8 +41,7 @@ const ArtistImage = ({ artist, controls }: ArtistImageProps) => {
   );
 };
 
-const Container = styled.div`
-  width: 140px;
+const Container = styled(motion.div)`
   height: 180px;
 `;
 

--- a/src/components/artists/ArtistImage.tsx
+++ b/src/components/artists/ArtistImage.tsx
@@ -33,7 +33,10 @@ const ArtistImage = ({ artist, controls }: ArtistImageProps) => {
   );
 };
 
-const Container = styled.div``;
+const Container = styled.div`
+  width: 140px;
+  height: 180px;
+`;
 
 const Background = styled(motion.div)<{ $color: string[][] }>`
   position: absolute;


### PR DESCRIPTION
## 개요

아티스트 이미지가 안떠도 UI는 꺠지지 않게 수정

## 스크린샷

![image](https://github.com/wakmusic/wakmusic-pc/assets/61264156/57c0ed1e-4e2c-4d85-a98d-6081f90ee234)