### PR TITLE
✏️ 검색 페이지의 가이드바 타이포 이슈

### DIFF
--- a/src/components/search/tabs/List.tsx
+++ b/src/components/search/tabs/List.tsx
@@ -83,9 +83,9 @@ const List = ({ tab, query }: ListProps) => {
       <GuideBar
         features={[
           GuideBarFeature.info,
-          GuideBarFeature.last,
           GuideBarFeature.date,
           GuideBarFeature.views,
+          GuideBarFeature.like,
         ]}
       />
 


### PR DESCRIPTION
## 개요

검색 페이지의 가이드 바에 `발매일 / 조회수 / 좋아요` 라고 떠야 하는데 `1시간 전 / 발매일 / 조회수` 라고 표기되어 있었음