### PR TITLE
✨ 아티스트 이미지 클릭 시 맨 위로

### DIFF
--- a/src/animations/artist.ts
+++ b/src/animations/artist.ts
@@ -22,6 +22,7 @@ export const characterVariants: Variants = {
     y: 0,
     borderBottomLeftRadius: 0,
     borderBottomRightRadius: 0,
+    cursor: "auto",
   },
   round: {
     width: 68,
@@ -29,6 +30,7 @@ export const characterVariants: Variants = {
     y: -12,
     borderBottomLeftRadius: 100,
     borderBottomRightRadius: 100,
+    cursor: "pointer",
   },
 };
 

--- a/src/components/artists/ArtistImage.tsx
+++ b/src/components/artists/ArtistImage.tsx
@@ -14,9 +14,10 @@ import { addAlpha } from "@utils/utils";
 interface ArtistImageProps {
   artist: Artist;
   controls: AnimationControls;
+  scrollToTop?: () => void;
 }
 
-const ArtistImage = ({ artist, controls }: ArtistImageProps) => {
+const ArtistImage = ({ artist, controls, scrollToTop }: ArtistImageProps) => {
   return (
     <Container
       animate={controls}
@@ -36,6 +37,7 @@ const ArtistImage = ({ artist, controls }: ArtistImageProps) => {
         animate={controls}
         initial="square"
         variants={characterVariants}
+        onClick={scrollToTop}
       />
     </Container>
   );

--- a/src/components/artists/ArtistInfo.tsx
+++ b/src/components/artists/ArtistInfo.tsx
@@ -29,6 +29,8 @@ interface ArtistInfoProps {
   small: boolean;
 
   isLoading?: boolean;
+
+  scrollToTop?: () => void;
 }
 
 const ArtistInfo = ({
@@ -36,6 +38,7 @@ const ArtistInfo = ({
   controls,
   small,
   isLoading,
+  scrollToTop,
 }: ArtistInfoProps) => {
   const [descriptionOpen, setDescriptionOpen] = useState(false);
 
@@ -70,7 +73,11 @@ const ArtistInfo = ({
       <Background $color={artist.color.background} />
 
       <InnerContainer>
-        <ArtistImage artist={artist} controls={controls} />
+        <ArtistImage
+          artist={artist}
+          controls={controls}
+          scrollToTop={scrollToTop}
+        />
 
         <Content animate={controls} initial="square" variants={contentVariants}>
           <T3Medium color={colors.gray900}>

--- a/src/pages/artists/Artist.tsx
+++ b/src/pages/artists/Artist.tsx
@@ -126,6 +126,10 @@ const Artist = ({}: ArtistProps) => {
     }
   }, [animationState, controls, scroll]);
 
+  const scrollToTop = () => {
+    viewportRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
   // TODO: 스켈레톤, 오류
   if (artistsError || albumsError) return <div>에러 발생!</div>;
 
@@ -137,6 +141,7 @@ const Artist = ({}: ArtistProps) => {
           controls={controls}
           small={scroll > 0}
           isLoading={artistsIsLoading}
+          scrollToTop={scrollToTop}
         />
 
         <TabBarWrapper>


### PR DESCRIPTION
## 개요

아티스트 상세 페이지에서 스크롤이 되어서 이미지가 동그래질 때, 그 이미지를 클릭할 시 아티스트 상세 페이지의 맨 위로 이동하는 기능 제작