### PR TITLE
✨ 플레이어 interval을 250ms로 변경

### DIFF
--- a/src/components/player/Visual/Visual.tsx
+++ b/src/components/player/Visual/Visual.tsx
@@ -57,6 +57,10 @@ const Visual = ({}: VisualProps) => {
     }
   }, [controls, visualMode]);
 
+  if (!visualMode) {
+    return null;
+  }
+
   return (
     <Container
       ref={ref}

--- a/src/player/PlayerService.tsx
+++ b/src/player/PlayerService.tsx
@@ -55,8 +55,8 @@ const PlayerService = ({}: PlayerServiceProps) => {
   useInterval(() => {
     if (!currentSongState || !control.isPlaying || isControlling) return;
 
-    setCurrentProgress((prev) => prev + 1);
-  }, 1000);
+    setCurrentProgress((prev) => prev + 0.25);
+  }, 250);
 
   useEffect(() => {
     if (!currentSongState || currentSongState?.songId === previousSong?.songId)
@@ -117,7 +117,7 @@ const PlayerService = ({}: PlayerServiceProps) => {
   useEffect(() => {
     if (currentSongState) return;
 
-    setLength(1);
+    setLength(0.1);
     setCurrentProgress(0);
     setControl((prev) => ({
       ...prev,

--- a/src/state/player/atoms.ts
+++ b/src/state/player/atoms.ts
@@ -53,7 +53,7 @@ export const isControlling = atom<boolean>({
 
 export const playingLength = atom<number>({
   key: "playingLength",
-  default: 1,
+  default: 0.1,
 });
 
 export const playingProgress = atom<number>({


### PR DESCRIPTION
## 개요

플레이어 interval을 250ms로 변경

## 이슈

- #216 

## 작업 내용

- 플레이어 interval을 250ms로 변경
- 비주얼모드가 활성화 되어있지 않을 때 렌더하지 않기 (최적화)
