### PR TITLE
🐛 플레이리스트 편집 기능 수정

### DIFF
--- a/src/pages/playerPlaylist/PlayerPlaylist.tsx
+++ b/src/pages/playerPlaylist/PlayerPlaylist.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import styled from "styled-components/macro";
 
 import { T4Medium } from "@components/Typography/Medium";
@@ -10,12 +10,14 @@ import MusicController from "@components/globals/musicControllers/MusicControlle
 import PageContainer from "@layouts/PageContainer";
 import PageLayout from "@layouts/PageLayout";
 
-import { usePlayingInfoState } from "@hooks/player";
+import { useCurrentSongState, usePlayingInfoState } from "@hooks/player";
 import { useSelectSongs } from "@hooks/selectSongs";
 
 import { ControllerFeature } from "@templates/musicController";
 import { Song } from "@templates/song";
 import { SongItemFeature } from "@templates/songItem";
+
+import { isNull } from "@utils/isTypes";
 
 interface PlayerPlaylistProps {}
 
@@ -24,15 +26,31 @@ const PlayerPlaylist = ({}: PlayerPlaylistProps) => {
   const [playingInfo, setPlayingInfo] = usePlayingInfoState();
   const { selected, selectCallback, selectedIncludes } = useSelectSongs();
 
+  const [changePlaylist, setChangePlaylist] = useState<Song[] | null>(null);
+
+  const currentSong = useCurrentSongState();
+
+  useEffect(() => {
+    if (!isEdit && !isNull(changePlaylist)) {
+      setPlayingInfo((prev) => ({
+        ...prev,
+        playlist: changePlaylist,
+        current: changePlaylist.findIndex(
+          (song) => song.songId === currentSong.songId
+        ),
+      }));
+    }
+  }, [isEdit, changePlaylist, setPlayingInfo, currentSong.songId]);
+
   const dispatchPlayerListInfo = async (songs: Song[]) => {
     const removedSongs = playingInfo.playlist.filter((playerSong) =>
       Boolean(songs.find((song) => song.songId === playerSong.songId))
     );
 
     if (removedSongs.length !== playingInfo.playlist.length) {
-      setPlayingInfo({ ...playingInfo, playlist: removedSongs });
+      setChangePlaylist(removedSongs);
     } else {
-      setPlayingInfo({ ...playingInfo, playlist: songs });
+      setChangePlaylist(songs);
     }
   };
 


### PR DESCRIPTION
## 개요

플레이리스트 편집 기능 수정

## 이슈

- #198

## 작업 내용

- 플레이어 플레이리스트에서 편집 모드를 활성화하고 노래를 바꾸고 나서 완료를 눌러야 적용되어야 하는 문제 해결
- 재생중인 곡 위에 곡이 추가되거나 사라져서 인덱스가 바뀌어서 다른 곡으로 넘어가는 문제 해결