### PR TITLE
🐛 공지사항 페이지에서 queryKey 변경

### DIFF
--- a/src/pages/notice/Notice.tsx
+++ b/src/pages/notice/Notice.tsx
@@ -27,7 +27,7 @@ const Notice = ({}: NoticeProps) => {
   });
 
   const { data: notice, error: noticeError } = useQuery({
-    queryKey: "notice",
+    queryKey: "noticeAll",
     queryFn: fetchAllNotice,
   });
 


### PR DESCRIPTION
## 개요

공지사항 페이지에서 queryKey 변경

평소 메인에서는 공지 모달이 안뜨다 공지사항 페이지만 들어가면 모달이 뜨는걸 보아서 왜 이러나 했는데 활성화된 공지 모달에서의 queryKey와 전체 공지사항을 보여주는 공지사항 페이지의 queryKey가 같아서 문제가 발생하던거였음

## 이슈

- #232
