### PR TITLE
:construction_worker: macOS에서의 앱 이름 한글화

### DIFF
--- a/build/macos/ko.lproj/InfoPlist.strings
+++ b/build/macos/ko.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+"CFBundleName" = "왁타버스 뮤직";
+
+"CFBundleDisplayName" = "왁타버스 뮤직";

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -58,27 +58,27 @@ const config: ForgeConfig = {
       },
     ],
 
-    // osxSign: {
-    //   type: "distribution",
-    //   identityValidation: true,
-    //   identity: process.env.APPLE_IDENTITY,
-    //   provisioningProfile: process.env.PP_PATH,
-    //   optionsForFile: (_) => {
-    //     return {
-    //       hardenedRuntime: true,
-    //       entitlements: "./build/macos/entitlements.plist",
-    //     };
-    //   },
-    //   strictVerify: true,
-    //   preAutoEntitlements: false,
-    //   preEmbedProvisioningProfile: false,
-    // },
-    // osxNotarize: {
-    //   tool: "notarytool",
-    //   appleId: process.env.APPLE_ID ?? "",
-    //   appleIdPassword: process.env.APPLE_PASSWORD ?? "",
-    //   teamId: process.env.APPLE_TEAM_ID ?? "",
-    // },
+    osxSign: {
+      type: "distribution",
+      identityValidation: true,
+      identity: process.env.APPLE_IDENTITY,
+      provisioningProfile: process.env.PP_PATH,
+      optionsForFile: (_) => {
+        return {
+          hardenedRuntime: true,
+          entitlements: "./build/macos/entitlements.plist",
+        };
+      },
+      strictVerify: true,
+      preAutoEntitlements: false,
+      preEmbedProvisioningProfile: false,
+    },
+    osxNotarize: {
+      tool: "notarytool",
+      appleId: process.env.APPLE_ID ?? "",
+      appleIdPassword: process.env.APPLE_PASSWORD ?? "",
+      teamId: process.env.APPLE_TEAM_ID ?? "",
+    },
 
     extraResource: "./build/macos/ko.lproj/",
   },

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -7,9 +7,11 @@ dotenv.config();
 
 const config: ForgeConfig = {
   packagerConfig: {
+    name: "왁타버스 뮤직",
     icon: "./build/appicon",
     asar: true,
     appBundleId: "com.wakmusic-pc",
+    // helperBundleId: "com.wakmusic-pc.helper",
 
     ignore: [
       /.github/,
@@ -56,27 +58,27 @@ const config: ForgeConfig = {
       },
     ],
 
-    osxSign: {
-      type: "distribution",
-      identityValidation: true,
-      identity: process.env.APPLE_IDENTITY,
-      provisioningProfile: process.env.PP_PATH,
-      optionsForFile: (_) => {
-        return {
-          hardenedRuntime: true,
-          entitlements: "./build/macos/entitlements.plist",
-        };
-      },
-      strictVerify: true,
-      preAutoEntitlements: false,
-      preEmbedProvisioningProfile: false,
-    },
-    osxNotarize: {
-      tool: "notarytool",
-      appleId: process.env.APPLE_ID ?? "",
-      appleIdPassword: process.env.APPLE_PASSWORD ?? "",
-      teamId: process.env.APPLE_TEAM_ID ?? "",
-    },
+    // osxSign: {
+    //   type: "distribution",
+    //   identityValidation: true,
+    //   identity: process.env.APPLE_IDENTITY,
+    //   provisioningProfile: process.env.PP_PATH,
+    //   optionsForFile: (_) => {
+    //     return {
+    //       hardenedRuntime: true,
+    //       entitlements: "./build/macos/entitlements.plist",
+    //     };
+    //   },
+    //   strictVerify: true,
+    //   preAutoEntitlements: false,
+    //   preEmbedProvisioningProfile: false,
+    // },
+    // osxNotarize: {
+    //   tool: "notarytool",
+    //   appleId: process.env.APPLE_ID ?? "",
+    //   appleIdPassword: process.env.APPLE_PASSWORD ?? "",
+    //   teamId: process.env.APPLE_TEAM_ID ?? "",
+    // },
   },
   rebuildConfig: {},
   makers: [

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -7,7 +7,7 @@ dotenv.config();
 
 const config: ForgeConfig = {
   packagerConfig: {
-    name: "왁타버스 뮤직",
+    name: "Wakmusic",
     icon: "./build/appicon",
     asar: true,
     appBundleId: "com.wakmusic-pc",
@@ -35,7 +35,8 @@ const config: ForgeConfig = {
     ],
 
     // afterCopy: [
-    //   async (buildPath, _electronVersion, _platform, _arch, callback) => {
+    //   async (buildPath, _electronVersion, platform, _arch, callback) => {
+    //     if (platform == "win32")
     //     const localeDir = join(buildPath, "../../locales");
 
     //     const files = await readdir(localeDir);
@@ -57,27 +58,29 @@ const config: ForgeConfig = {
       },
     ],
 
-    osxSign: {
-      type: "distribution",
-      identityValidation: true,
-      identity: process.env.APPLE_IDENTITY,
-      provisioningProfile: process.env.PP_PATH,
-      optionsForFile: (_) => {
-        return {
-          hardenedRuntime: true,
-          entitlements: "./build/macos/entitlements.plist",
-        };
-      },
-      strictVerify: true,
-      preAutoEntitlements: false,
-      preEmbedProvisioningProfile: false,
-    },
-    osxNotarize: {
-      tool: "notarytool",
-      appleId: process.env.APPLE_ID ?? "",
-      appleIdPassword: process.env.APPLE_PASSWORD ?? "",
-      teamId: process.env.APPLE_TEAM_ID ?? "",
-    },
+    // osxSign: {
+    //   type: "distribution",
+    //   identityValidation: true,
+    //   identity: process.env.APPLE_IDENTITY,
+    //   provisioningProfile: process.env.PP_PATH,
+    //   optionsForFile: (_) => {
+    //     return {
+    //       hardenedRuntime: true,
+    //       entitlements: "./build/macos/entitlements.plist",
+    //     };
+    //   },
+    //   strictVerify: true,
+    //   preAutoEntitlements: false,
+    //   preEmbedProvisioningProfile: false,
+    // },
+    // osxNotarize: {
+    //   tool: "notarytool",
+    //   appleId: process.env.APPLE_ID ?? "",
+    //   appleIdPassword: process.env.APPLE_PASSWORD ?? "",
+    //   teamId: process.env.APPLE_TEAM_ID ?? "",
+    // },
+
+    extraResource: "./build/macos/ko.lproj/",
   },
   rebuildConfig: {},
   makers: [

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -11,7 +11,6 @@ const config: ForgeConfig = {
     icon: "./build/appicon",
     asar: true,
     appBundleId: "com.wakmusic-pc",
-    // helperBundleId: "com.wakmusic-pc.helper",
 
     ignore: [
       /.github/,
@@ -58,27 +57,27 @@ const config: ForgeConfig = {
       },
     ],
 
-    // osxSign: {
-    //   type: "distribution",
-    //   identityValidation: true,
-    //   identity: process.env.APPLE_IDENTITY,
-    //   provisioningProfile: process.env.PP_PATH,
-    //   optionsForFile: (_) => {
-    //     return {
-    //       hardenedRuntime: true,
-    //       entitlements: "./build/macos/entitlements.plist",
-    //     };
-    //   },
-    //   strictVerify: true,
-    //   preAutoEntitlements: false,
-    //   preEmbedProvisioningProfile: false,
-    // },
-    // osxNotarize: {
-    //   tool: "notarytool",
-    //   appleId: process.env.APPLE_ID ?? "",
-    //   appleIdPassword: process.env.APPLE_PASSWORD ?? "",
-    //   teamId: process.env.APPLE_TEAM_ID ?? "",
-    // },
+    osxSign: {
+      type: "distribution",
+      identityValidation: true,
+      identity: process.env.APPLE_IDENTITY,
+      provisioningProfile: process.env.PP_PATH,
+      optionsForFile: (_) => {
+        return {
+          hardenedRuntime: true,
+          entitlements: "./build/macos/entitlements.plist",
+        };
+      },
+      strictVerify: true,
+      preAutoEntitlements: false,
+      preEmbedProvisioningProfile: false,
+    },
+    osxNotarize: {
+      tool: "notarytool",
+      appleId: process.env.APPLE_ID ?? "",
+      appleIdPassword: process.env.APPLE_PASSWORD ?? "",
+      teamId: process.env.APPLE_TEAM_ID ?? "",
+    },
   },
   rebuildConfig: {},
   makers: [


### PR DESCRIPTION
## 개요

기존에 사이닝 문제로 앱 이름으로 wakscord-pc를 사용해야 했으나, 이를 사이닝 문제 없이 한글화하였습니다.

## 작업 내용

- Resources/ko.lproj에 InfoPlist.strings를 추가하여 각 앱(메인, 헬퍼)의 각종 파일들(Info.plist, MacOS 내의 실행 파일 등)을 영어 이름을 유지한 채 시스템 상에서 한글로 보이도록 하였습니다. (카카오톡 패키지 내용 참고)
