### PR TITLE
:wrench: 윈도우 빌드 용량 개선 & 맥 빌드 불필요한 폴더 제거

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -33,21 +33,34 @@ const config: ForgeConfig = {
       /node_modules\/.vite/,
     ],
 
-    // afterCopy: [
-    //   async (buildPath, _electronVersion, platform, _arch, callback) => {
-    //     const localeDir = join(buildPath, "../../locales");
+    afterCopy: [
+      async (buildPath, _electronVersion, platform, _arch, callback) => {
+        if (platform == "win32") {
+          const localeDir = join(buildPath, "../../locales");
 
-    //     const files = await readdir(localeDir);
+          const files = await readdir(localeDir);
 
-    //     for (const file of files) {
-    //       if (file !== "en-US.pak") {
-    //         await unlink(join(localeDir, file));
-    //       }
-    //     }
+          for (const file of files) {
+            if (file !== "en-US.pak") {
+              await unlink(join(localeDir, file));
+            }
+          }
+        }
+        if (platform == "darwin") {
+          const resourcesDir = join(buildPath, "../../Resources");
 
-    //     callback();
-    //   },
-    // ],
+          const files = await readdir(resourcesDir);
+
+          for (const file of files) {
+            if (file.endsWith(".lproj") && file !== "ko.lproj") {
+              await rmdir(join(resourcesDir, file));
+            }
+          }
+        }
+
+        callback();
+      },
+    ],
 
     protocols: [
       {


### PR DESCRIPTION
## 개요

맥 빌드 추가 당시 삭제되었던 윈도우 빌드 용량 개선 스크립트를 복구하고, 맥 빌드에서 불필요한 언어 관련 폴더들을 제거하는 스크립트를 추가하였습니다.

## 작업 내용

- afterCopy 훅 복구
- 플랫폼을 구별해 기존 스크립트를 Win32에서만 실행하도록 수정
- Darwin 최적화 관련 스크립트 추가

## 스크린샷

기존 빌드
![image](https://github.com/wakmusic/wakmusic-pc/assets/97957043/e57e1eef-38e5-4f1b-b67a-0b83763e46a0)
최적화 빌드
![image](https://github.com/wakmusic/wakmusic-pc/assets/97957043/1288c2fa-d2f1-4d52-a035-7d04a90e93f9)