### PR TITLE
✨ 중복으로 담기는 버그 수정, 새로운 노래 재생

### DIFF
--- a/src/components/globals/musicControllers/MusicController.tsx
+++ b/src/components/globals/musicControllers/MusicController.tsx
@@ -3,7 +3,7 @@ import { useLocation } from "react-router-dom";
 import styled from "styled-components/macro";
 
 import { useAddListModal } from "@hooks/addListModal";
-import { useControlState, usePlayingInfoState } from "@hooks/player";
+import { usePlaySongs } from "@hooks/player";
 
 import { ControllerFeature } from "@templates/musicController";
 import { Song } from "@templates/song";
@@ -53,32 +53,13 @@ const MusicController = ({
     useState(displayDefault);
   const [popdown, setPopdown] = useState(false);
 
-  const [, setPlayingInfo] = usePlayingInfoState();
-  const [, setControlState] = useControlState();
-
   const [selectedLength, setSelectedLength] = useState(selectedSongs.length);
 
   const openAddListModal = useAddListModal();
 
   const location = useLocation();
 
-  const addSongs = useCallback(
-    (list: Song[], play?: boolean) => {
-      // 재생목록에 노래 추가
-      setPlayingInfo((prev) => ({
-        playlist: [...prev.playlist, ...list],
-        original: [],
-        current: play ? prev.playlist.length : prev.current,
-      }));
-
-      if (!play) return;
-      setControlState((prev) => ({
-        ...prev,
-        isPlaying: true,
-      }));
-    },
-    [setControlState, setPlayingInfo]
-  );
+  const playSongs = usePlaySongs();
 
   const getControllerComponent = useCallback(
     (feature: ControllerFeature, key: number) => {
@@ -139,7 +120,7 @@ const MusicController = ({
           return (
             <AddPlaylist
               onClick={() => {
-                addSongs(selectedSongs);
+                playSongs(selectedSongs, false, false);
                 dispatchSelectedSongs([]);
               }}
               key={key}
@@ -149,7 +130,7 @@ const MusicController = ({
           return (
             <PlayMusic
               onClick={() => {
-                addSongs(selectedSongs, true);
+                playSongs(selectedSongs);
                 dispatchSelectedSongs([]);
               }}
               key={key}
@@ -178,11 +159,11 @@ const MusicController = ({
       }
     },
     [
-      addSongs,
       dispatchSelectedSongs,
       location.pathname,
       onDelete,
       openAddListModal,
+      playSongs,
       selectedSongs,
       songs,
     ]

--- a/src/hooks/player.ts
+++ b/src/hooks/player.ts
@@ -322,13 +322,36 @@ export const usePlaySong = () => {
 export const usePlaySongs = () => {
   const setPlayingInfo = useSetRecoilState(playingInfoState);
 
-  return (songs: Song[], shuffle = false) => {
-    const _songs = shuffle ? [...songs].sort(() => Math.random() - 0.5) : songs;
+  return (songs: Song[], shuffle = false, play = true) => {
+    const addSongs = shuffle
+      ? [...songs].sort(() => Math.random() - 0.5)
+      : songs;
 
-    setPlayingInfo({
-      playlist: _songs,
-      original: [],
-      current: 0,
+    setPlayingInfo((prev) => {
+      const oldPlaylist = [...prev.playlist];
+
+      for (const song of addSongs) {
+        const index = oldPlaylist.findIndex(
+          (item) => item.songId === song.songId
+        );
+
+        if (index !== -1) {
+          oldPlaylist.splice(index, 1);
+        }
+      }
+
+      const newPlaylist = [...oldPlaylist, ...addSongs];
+
+      return {
+        ...prev,
+        current: newPlaylist.findIndex(
+          (item) =>
+            item.songId ===
+            (play ? songs[0] : prev.playlist[prev.current]).songId
+        ),
+        playlist: newPlaylist,
+        original: newPlaylist,
+      };
     });
   };
 };


### PR DESCRIPTION
## 개요

중복으로 담기는 버그 수정, 새로운 노래 재생

## 작업 내용

- 새 플레이리스트를 재생할 때 재생목록을 초기화하고 넣는 것이 아닌 맨 밑에 추가. 단 이미 있는 곡일 경우 밑으로 끌어내림
  - iOS과 동일하게 제작: https://github.com/wakmusic/wakmusic-iOS/pull/374
- 뮤직 컨트롤러에서 재생목록추가 or 재생할 때 중복으로 노래가 담기는 문제 해결
