### PR TITLE
Fix/lyric scroll

### DIFF
--- a/src/components/player/Default/Display.tsx
+++ b/src/components/player/Default/Display.tsx
@@ -122,7 +122,7 @@ const Display = ({}: DisplayProps) => {
               variants={buttonVariants}
               initial="close"
             >
-              <Lyrics size="small" />
+              <Lyrics size="small" isVisualMode={false} />
             </LyricsWrapper>
             <Thumbnail
               src={img}

--- a/src/components/player/Lyrics.tsx
+++ b/src/components/player/Lyrics.tsx
@@ -108,7 +108,6 @@ const Lyrics = ({ size, isVisualMode }: LyricsProps) => {
 
       ref.current.scrollTo({
         top: 0,
-        behavior: "instant",
       });
 
       setPrvLyrics(lyrics);

--- a/src/components/player/Lyrics.tsx
+++ b/src/components/player/Lyrics.tsx
@@ -84,6 +84,10 @@ const Lyrics = ({ size, isVisualMode }: LyricsProps) => {
         padding +
         currentRef.current.offsetHeight / 2;
 
+      if (Math.abs(ref.current.scrollTop - top) > 300) {
+        setTimeout(1);
+      }
+
       ref.current.scrollTo({
         top,
         behavior: (isSmooth ? "smooth" : "instant") as ScrollBehavior,
@@ -93,7 +97,7 @@ const Lyrics = ({ size, isVisualMode }: LyricsProps) => {
   );
 
   useEffect(() => {
-    if (timeout !== 0) return;
+    if (timeout > 0) return;
 
     setPosition(true);
   }, [setPosition, timeout]);
@@ -109,7 +113,7 @@ const Lyrics = ({ size, isVisualMode }: LyricsProps) => {
 
       setPrvLyrics(lyrics);
     }
-  }, [lyrics, prvLyrics, setPosition]);
+  }, [lyrics, prvLyrics]);
 
   useEffect(() => {
     if (visualMode !== prvVisualMode) {
@@ -122,7 +126,7 @@ const Lyrics = ({ size, isVisualMode }: LyricsProps) => {
 
   useInterval(() => {
     setTimeout((prev) => {
-      if (prev === 0) return 0;
+      if (prev < 0) return 0;
 
       return prev - 1;
     });

--- a/src/components/player/Visual/DefaultMode.tsx
+++ b/src/components/player/Visual/DefaultMode.tsx
@@ -40,7 +40,7 @@ const DefaultMode = ({}: DefaultModeProps) => {
         <Thumbnail src={img} onClick={toggleVisualModeState} />
 
         <LyricsContainer>
-          <Lyrics size="large" />
+          <Lyrics size="large" isVisualMode={true} />
         </LyricsContainer>
 
         <TimelineContainer>

--- a/src/components/player/Visual/LyricsMode.tsx
+++ b/src/components/player/Visual/LyricsMode.tsx
@@ -31,7 +31,7 @@ const LyricsMode = ({}: LyricsModeProps) => {
       </TitleContainer>
 
       <LyricsContainer>
-        <Lyrics size="large" />
+        <Lyrics size="large" isVisualMode={true} />
       </LyricsContainer>
 
       <TimelineContainer>

--- a/src/components/player/Visual/Visual.tsx
+++ b/src/components/player/Visual/Visual.tsx
@@ -66,17 +66,15 @@ const Visual = ({}: VisualProps) => {
       variants={visualVariants}
       initial="initial"
     >
-      {visualMode ? (
-        <Wrapper $zoom={zoom}>
-          <Header />
-          <InnerContainer $zoom={zoom}>
-            <InnerWrapper $zoom={zoom}>
-              <LyricsMode />
-              <DefaultMode />
-            </InnerWrapper>
-          </InnerContainer>
-        </Wrapper>
-      ) : null}
+      <Wrapper $zoom={zoom}>
+        <Header />
+        <InnerContainer $zoom={zoom}>
+          <InnerWrapper $zoom={zoom}>
+            <LyricsMode />
+            <DefaultMode />
+          </InnerWrapper>
+        </InnerContainer>
+      </Wrapper>
     </Container>
   );
 };


### PR DESCRIPTION
## 개요

가사 스크롤 픽스

## 작업 내용

- 다른 곡을 재생하면 가사의 첫 부분으로 점프
- visual모드 on off할 때 현재 재생중인 곳의 가사로 점프
- 재생중에 긴 길이를 smooth 스크롤하면 약간 끊기던 현상 해결