### PR TITLE
🐛 이상한 플레이어 수정

### DIFF
--- a/src/components/player/Default/Player.tsx
+++ b/src/components/player/Default/Player.tsx
@@ -32,6 +32,8 @@ const Container = styled.div`
   background-color: ${colors.gray900};
 
   overflow: hidden;
+
+  margin-left: -0.5px;
 `;
 
 const Divider = styled.div`

--- a/src/components/player/Default/Playlist.tsx
+++ b/src/components/player/Default/Playlist.tsx
@@ -10,7 +10,7 @@ import VirtualItem from "@layouts/VirtualItem";
 import colors from "@constants/colors";
 
 import { useInterval } from "@hooks/interval";
-import { usePlayingInfoState } from "@hooks/player";
+import { useControlState, usePlayingInfoState } from "@hooks/player";
 import { useSelectSongs } from "@hooks/selectSongs";
 import useVirtualizer from "@hooks/virtualizer";
 
@@ -22,6 +22,7 @@ import { addAlpha } from "@utils/utils";
 interface PlaylistProps {}
 
 const Playlist = ({}: PlaylistProps) => {
+  const [, setControl] = useControlState();
   const [playingInfo, setPlayingInfo] = usePlayingInfoState();
   const [playlistData, setPlaylistData] = useState<
     (Song & {
@@ -83,6 +84,10 @@ const Playlist = ({}: PlaylistProps) => {
 
   function onSongDoubleClicked(index: number) {
     setPlayingInfo({ ...playingInfo, current: index });
+    setControl((prev) => ({
+      ...prev,
+      isPlaying: true,
+    }));
   }
 
   const getCursorIndex = useCallback(() => {

--- a/src/components/player/Lyrics.tsx
+++ b/src/components/player/Lyrics.tsx
@@ -144,6 +144,10 @@ const Lyrics = ({ size, isVisualMode }: LyricsProps) => {
     };
   }, [setPosition]);
 
+  if (!current) {
+    return <NoLyricsContainer />;
+  }
+
   if (!lyrics) {
     return (
       <NoLyricsContainer>

--- a/src/hooks/player.ts
+++ b/src/hooks/player.ts
@@ -22,6 +22,8 @@ import {
 } from "@templates/player";
 import { Song } from "@templates/song";
 
+import { isNil } from "@utils/isTypes";
+
 export const usePlayingLengthState = () => {
   return useRecoilState(playingLength);
 };
@@ -89,8 +91,8 @@ export const useToggleIsRandomState = () => {
 
   return () => {
     setPlayingInfo((prev) => {
-      let newPlaylist;
-      let current;
+      let newPlaylist: Song[] = [];
+      let current = 0;
 
       if (!state.isRandom) {
         const shuffledPlaylist = [...prev.original].sort(
@@ -101,12 +103,13 @@ export const useToggleIsRandomState = () => {
           (item) => item.songId === prev.playlist[prev.current].songId
         );
 
-        current = 0;
-        newPlaylist = [
-          shuffledPlaylist[movedCurrent],
-          ...shuffledPlaylist.slice(0, movedCurrent),
-          ...shuffledPlaylist.slice(movedCurrent + 1),
-        ];
+        if (movedCurrent !== -1) {
+          newPlaylist = [
+            shuffledPlaylist[movedCurrent],
+            ...shuffledPlaylist.slice(0, movedCurrent),
+            ...shuffledPlaylist.slice(movedCurrent + 1),
+          ];
+        }
       } else {
         newPlaylist = [...prev.original];
         current = newPlaylist.findIndex(
@@ -329,8 +332,11 @@ export const usePlaySongs = () => {
       const oldPlaylist = [...prev.playlist];
 
       for (const song of addSongs) {
+        if (isNil(song)) continue;
+        console.log(song);
+
         const index = oldPlaylist.findIndex(
-          (item) => item.songId === song.songId
+          (item) => item?.songId === song.songId
         );
 
         if (index !== -1) {
@@ -350,7 +356,7 @@ export const usePlaySongs = () => {
           : 0,
 
         playlist: newPlaylist,
-        original: newPlaylist,
+        original: [],
       };
     });
   };

--- a/src/player/providers/YouTube.tsx
+++ b/src/player/providers/YouTube.tsx
@@ -243,7 +243,9 @@ const YouTube = ({
     if (!player.current) return;
 
     if (isPlaying) {
-      if (playerState.current.isFirst) return;
+      if (playerState.current.isFirst) {
+        return;
+      }
 
       player.current.playVideo();
     } else {


### PR DESCRIPTION
## 개요

이상한 플레이어 수정

## 작업 내용

- 재생중인 곡이 없을 때 가사 띄우지 않기
- 셔플 연타시 이상하게 작동하던거 수정
- 정지된 상태의 플레이어에서 더블클릭시 재생
- 디스플레이 배율이 되어있을떄 하얀 줄 1px 나오던거 수정