### PR TITLE
플레이어 플레이리스트 사용성 개선

### DIFF
--- a/src/components/globals/musicControllers/musicControllerContainers/MusicControllerPlayer.tsx
+++ b/src/components/globals/musicControllers/musicControllerContainers/MusicControllerPlayer.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import styled, { css, keyframes } from "styled-components/macro";
+import styled, { keyframes } from "styled-components/macro";
 
 import { T4Bold } from "@components/Typography/Bold";
 

--- a/src/components/globals/musicControllers/musicControllerContainers/MusicControllerPlayer.tsx
+++ b/src/components/globals/musicControllers/musicControllerContainers/MusicControllerPlayer.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import styled, { keyframes } from "styled-components/macro";
+import styled, { css, keyframes } from "styled-components/macro";
 
 import { T4Bold } from "@components/Typography/Bold";
 
@@ -32,6 +32,10 @@ const Popup = keyframes`
   0% {
     bottom: -75px;
   }
+  
+  60% {
+    bottom: -75px;
+  }
 
   100% {
     bottom: 0;
@@ -51,8 +55,14 @@ const Popdown = keyframes`
 const Wrapper = styled.div<{ $popdown: boolean }>`
   position: fixed;
 
-  animation: ${({ $popdown }) => ($popdown ? Popdown : Popup)} 0.25s ease-out
-    forwards;
+  ${({ $popdown }) =>
+    $popdown
+      ? css`
+          animation: ${Popdown} 0.25s ease-out forwards;
+        `
+      : css`
+          animation: ${Popup} 0.35s ease-out forwards;
+        `}
 `;
 
 const ButtonContainer = styled.div`

--- a/src/components/globals/musicControllers/musicControllerContainers/MusicControllerPlayer.tsx
+++ b/src/components/globals/musicControllers/musicControllerContainers/MusicControllerPlayer.tsx
@@ -32,10 +32,6 @@ const Popup = keyframes`
   0% {
     bottom: -75px;
   }
-  
-  60% {
-    bottom: -75px;
-  }
 
   100% {
     bottom: 0;
@@ -55,14 +51,8 @@ const Popdown = keyframes`
 const Wrapper = styled.div<{ $popdown: boolean }>`
   position: fixed;
 
-  ${({ $popdown }) =>
-    $popdown
-      ? css`
-          animation: ${Popdown} 0.25s ease-out forwards;
-        `
-      : css`
-          animation: ${Popup} 0.35s ease-out forwards;
-        `}
+  animation: ${({ $popdown }) => ($popdown ? Popdown : Popup)} 0.15s ease-out
+    forwards;
 `;
 
 const ButtonContainer = styled.div`

--- a/src/components/player/Default/Playlist.tsx
+++ b/src/components/player/Default/Playlist.tsx
@@ -28,6 +28,8 @@ const Playlist = ({}: PlaylistProps) => {
   const { selected, setSelected, selectCallback, selectedIncludes } =
     useSelectSongs();
 
+  const [mouseUp, setMouseUp] = useState(false);
+
   const [mouseState, setMouseState] = useState({
     isMouseDown: false,
     isMoving: false,
@@ -157,7 +159,11 @@ const Playlist = ({}: PlaylistProps) => {
     [mouseState]
   );
 
-  const handleMouseUp = useCallback(() => {
+  function handleMouseUp() {
+    setMouseUp(true);
+  }
+
+  const processMouseUp = useCallback(() => {
     if (!mouseState.isMouseDown) return;
 
     if (mouseState.isMoving && !scrollState.isScrollEnabled) {
@@ -186,13 +192,29 @@ const Playlist = ({}: PlaylistProps) => {
 
   useEffect(() => {
     window.addEventListener("mouseup", handleMouseUp);
-    window.addEventListener("mousemove", handleMouseMove);
 
     return () => {
       window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("mousemove", handleMouseMove);
+
+    return () => {
       window.removeEventListener("mousemove", handleMouseMove);
     };
-  }, [handleMouseUp, handleMouseMove]);
+  }, [handleMouseMove]);
+
+  useEffect(() => {
+    if (mouseUp) {
+      setMouseUp(false);
+
+      setTimeout(() => {
+        processMouseUp();
+      }, 10);
+    }
+  }, [mouseUp, processMouseUp]);
 
   useEffect(() => {
     if (!viewportRef.current) return;

--- a/src/components/player/Default/Playlist.tsx
+++ b/src/components/player/Default/Playlist.tsx
@@ -75,10 +75,23 @@ const Playlist = ({}: PlaylistProps) => {
         ) {
           const start = Math.min(index, lastSelected);
           const end = Math.max(index, lastSelected) + 1;
-          selectCallback([
+
+          const newSelected = [
             ...selected,
             ...[...playingInfo.playlist].slice(start, end),
-          ]);
+          ];
+
+          setSelected(
+            newSelected
+              .filter(
+                (s, i) =>
+                  newSelected.findIndex((ss) => s.songId === ss.songId) === i
+              )
+              .map((item, index) => ({
+                ...item,
+                index: index,
+              }))
+          );
         } else {
           selectCallback(playingInfo.playlist[index], index);
           setLastSelected(index);

--- a/src/components/player/Default/Playlist.tsx
+++ b/src/components/player/Default/Playlist.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useCallback, useEffect, useState } from "react";
-import styled, { css } from "styled-components/macro";
+import styled, { css, keyframes } from "styled-components/macro";
 
 import { T7Light } from "@components/Typography";
 import PlayerScroll from "@components/globals/Scroll/PlayerScroll";
@@ -286,14 +286,45 @@ const Playlist = ({}: PlaylistProps) => {
   );
 };
 
+const Popup = keyframes`
+  0% {
+    margin-bottom: 0;
+  }
+  
+  60% {
+    margin-bottom: 0;
+  }
+
+  100% {
+    margin-bottom: -60px;
+  }
+`;
+
+const Popdown = keyframes`
+  0% {
+    margin-bottom: -60px;
+  }
+
+  100% {
+    margin-bottom: 0;
+  }
+`;
+
 const Container = styled.div`
   padding: 16px 0;
 `;
 
 const Wrapper = styled.div<{ $appBarEnable: boolean }>`
-  height: calc(
-    100vh - 410px + ${({ $appBarEnable }) => ($appBarEnable ? -60 : 0)}px
-  );
+  height: calc(100vh - 410px);
+
+  ${({ $appBarEnable }) =>
+    $appBarEnable
+      ? css`
+          animation: ${Popup} 0.35s ease-out forwards;
+        `
+      : css`
+          animation: ${Popdown} 0.25s ease-out forwards;
+        `}
 `;
 
 const PlaylistContainer = styled.div<{ height: number }>`

--- a/src/components/player/Default/Playlist.tsx
+++ b/src/components/player/Default/Playlist.tsx
@@ -67,7 +67,12 @@ const Playlist = ({}: PlaylistProps) => {
 
     setClickTimer(
       setTimeout(() => {
-        if (multiSelect && lastSelected !== null && lastSelected !== index) {
+        if (
+          multiSelect &&
+          lastSelected !== null &&
+          lastSelected !== index &&
+          selectedIncludes(playingInfo.playlist[lastSelected], lastSelected)
+        ) {
           const start = Math.min(index, lastSelected);
           const end = Math.max(index, lastSelected) + 1;
           selectCallback([...playingInfo.playlist].slice(start, end));

--- a/src/components/player/Default/Playlist.tsx
+++ b/src/components/player/Default/Playlist.tsx
@@ -75,7 +75,10 @@ const Playlist = ({}: PlaylistProps) => {
         ) {
           const start = Math.min(index, lastSelected);
           const end = Math.max(index, lastSelected) + 1;
-          selectCallback([...playingInfo.playlist].slice(start, end));
+          selectCallback([
+            ...selected,
+            ...[...playingInfo.playlist].slice(start, end),
+          ]);
         } else {
           selectCallback(playingInfo.playlist[index], index);
           setLastSelected(index);

--- a/src/components/player/Default/Playlist.tsx
+++ b/src/components/player/Default/Playlist.tsx
@@ -263,7 +263,7 @@ const Playlist = ({}: PlaylistProps) => {
     }
 
     if (scroll === 0) {
-      setScrollState({ ...scrollState, isScrolling: false });
+      setScrollState({ isScrollEnabled: false, isScrolling: false });
 
       return;
     }

--- a/src/components/player/Visual/Visual.tsx
+++ b/src/components/player/Visual/Visual.tsx
@@ -30,9 +30,7 @@ const Visual = ({}: VisualProps) => {
   const [zoom, setZoom] = useState(1);
 
   useEffect(() => {
-    if (!ref.current) {
-      return;
-    }
+    if (!ref.current) return;
 
     const resizeObserver = new ResizeObserver(() => {
       setZoom(


### PR DESCRIPTION
## 개요

플레이어 플레이리스트 사용성 개선

## 이슈

#122 

## 작업 내용

- 앱바 팝업에 딜레이 추가 (플레이리스트 맨 밑에서 곡 더블클릭 가능)
- 플레이리스트 맨 밑에서 곡 선택하면 자동 스크롤
- 곡이 재생중일 때 플레이어 플레이리스트에서 곡을 드래그하면 mouseup 이벤트가 발생하지 않는 현상 픽스
- 드래그해서 스크롤하면 MovementCursor가 깜빡거리던 버그 픽스