### PR TITLE
셔플 관련 버그 픽스

### DIFF
--- a/src/components/player/Default/Playlist.tsx
+++ b/src/components/player/Default/Playlist.tsx
@@ -22,7 +22,7 @@ import { addAlpha } from "@utils/utils";
 interface PlaylistProps {}
 
 const Playlist = ({}: PlaylistProps) => {
-  const [, setControl] = useControlState();
+  const [controlState, setControl] = useControlState();
   const [playingInfo, setPlayingInfo] = usePlayingInfoState();
 
   const { selected, setSelected, selectCallback, selectManyCallback } =
@@ -127,16 +127,23 @@ const Playlist = ({}: PlaylistProps) => {
     );
 
     setPlayingInfo((prev) => ({
-      ...prev,
       playlist: newPlaylist,
       current: newPlaylist.findIndex(
         (song) =>
           song.songId === playingInfo.playlist[playingInfo.current].songId
       ),
+      original: controlState.isRandom ? prev.original : newPlaylist,
     }));
     setLastSelected(null);
     setSelected([]);
-  }, [playingInfo, setPlayingInfo, targetIndex, getCursorIndex, setSelected]);
+  }, [
+    playingInfo,
+    controlState,
+    setPlayingInfo,
+    targetIndex,
+    getCursorIndex,
+    setSelected,
+  ]);
 
   const deleteSongs = useCallback(
     (newSongs: Song[]) => {

--- a/src/components/player/Default/Playlist.tsx
+++ b/src/components/player/Default/Playlist.tsx
@@ -74,6 +74,7 @@ const Playlist = ({}: PlaylistProps) => {
     setClickTimer(
       setTimeout(() => {
         selectCallback(playingInfo.playlist[index], shift);
+        setLastSelected(index);
       }, 250)
     );
   }

--- a/src/hooks/player.ts
+++ b/src/hooks/player.ts
@@ -364,10 +364,10 @@ export const usePlaySongs = () => {
         ...prev,
         current: currentSong
           ? newPlaylist.findIndex(
-              (item) => item.songId === (play ? songs[0] : currentSong).songId
+              (item) =>
+                item.songId === (play ? addSongs[0] : currentSong).songId
             )
           : 0,
-
         playlist: newPlaylist,
         original: [],
       };

--- a/src/hooks/player.ts
+++ b/src/hooks/player.ts
@@ -99,16 +99,20 @@ export const useToggleIsRandomState = () => {
           () => Math.random() - 0.5
         );
 
-        const movedCurrent = shuffledPlaylist.findIndex(
-          (item) => item.songId === prev.playlist[prev.current].songId
-        );
+        if (forceShuffle) {
+          newPlaylist = shuffledPlaylist;
+        } else {
+          const movedCurrent = shuffledPlaylist.findIndex(
+            (item) => item.songId === prev.playlist[prev.current].songId
+          );
 
-        if (movedCurrent !== -1) {
-          newPlaylist = [
-            shuffledPlaylist[movedCurrent],
-            ...shuffledPlaylist.slice(0, movedCurrent),
-            ...shuffledPlaylist.slice(movedCurrent + 1),
-          ];
+          if (movedCurrent !== -1) {
+            newPlaylist = [
+              shuffledPlaylist[movedCurrent],
+              ...shuffledPlaylist.slice(0, movedCurrent),
+              ...shuffledPlaylist.slice(movedCurrent + 1),
+            ];
+          }
         }
       } else {
         newPlaylist = [...prev.original];
@@ -258,8 +262,7 @@ export const useNextSong = () => {
 
           setPlayingInfo((prev) => ({
             ...prev,
-            current:
-              control.isRandom && playingInfo.playlist.length > 1 ? 1 : 0,
+            current: 0,
           }));
 
           setProgress({

--- a/src/hooks/player.ts
+++ b/src/hooks/player.ts
@@ -369,7 +369,7 @@ export const usePlaySongs = () => {
             )
           : 0,
         playlist: newPlaylist,
-        original: [],
+        original: newPlaylist,
       };
     });
   };

--- a/src/state/player/atoms.ts
+++ b/src/state/player/atoms.ts
@@ -93,7 +93,7 @@ export const playingInfoState = atom<PlayingInfoStateType>({
     original: localStorage.getItem("original")
       ? JSON.parse(localStorage.getItem("original") as string)
       : [],
-    current: 0,
+    current: Number(localStorage.getItem("current")) || 0,
   },
   effects: [
     // Discord RPC
@@ -147,6 +147,10 @@ export const playingInfoState = atom<PlayingInfoStateType>({
 
         if (value.original !== (oldValue as PlayingInfoStateType).original) {
           localStorage.setItem("original", JSON.stringify(value.original));
+        }
+
+        if (value.current !== (oldValue as PlayingInfoStateType).current) {
+          localStorage.setItem("current", JSON.stringify(value.current));
         }
       });
     },

--- a/src/state/player/atoms.ts
+++ b/src/state/player/atoms.ts
@@ -110,13 +110,20 @@ export const playingInfoState = atom<PlayingInfoStateType>({
         const nowPlaylist = value.playlist;
         const oldPlaylist = (oldValue as PlayingInfoStateType).playlist;
 
-        if (nowPlaylist.length !== oldPlaylist.length) {
+        if (
+          nowPlaylist.length !== oldPlaylist.length ||
+          nowPlaylist.some((item, i) => item.songId !== oldPlaylist[i].songId)
+        ) {
           const deleted = oldPlaylist.filter(
-            (item) => !nowPlaylist.includes(item)
+            (item) =>
+              nowPlaylist.findIndex((item2) => item.songId === item2.songId) ===
+              -1
           );
 
           const added = nowPlaylist.filter(
-            (item) => !oldPlaylist.includes(item)
+            (item) =>
+              oldPlaylist.findIndex((item2) => item.songId === item2.songId) ===
+              -1
           );
 
           const newOriginal = [...value.original];

--- a/src/state/player/atoms.ts
+++ b/src/state/player/atoms.ts
@@ -110,10 +110,7 @@ export const playingInfoState = atom<PlayingInfoStateType>({
         const nowPlaylist = value.playlist;
         const oldPlaylist = (oldValue as PlayingInfoStateType).playlist;
 
-        if (
-          nowPlaylist.length !== oldPlaylist.length ||
-          nowPlaylist.some((item, i) => item.songId !== oldPlaylist[i].songId)
-        ) {
+        if (nowPlaylist.length !== value.original.length) {
           const deleted = oldPlaylist.filter(
             (item) =>
               nowPlaylist.findIndex((item2) => item.songId === item2.songId) ===


### PR DESCRIPTION
## 개요

대부분 셔플 관련 버그 픽스
근데 버그가 더 있을거같아요
꼼꼼한 테스트 부탁

## 이슈

#275 #276 #267

## 작업 내용

- ✨ 현재 재생 곡 인덱스를 로컬스토리지에 저장
- 🐛 플레이어 플레이리스트에서 곡 순서를 변경해도 셔플의 원본 플레이리스트에는 적용되지 않는 버그 픽스
- 🐛 반복셔플 상태에서 마지막 곡에서 다시 첫번째 곡으로 넘어갈 때 index를 0으로 설정
- 🐛 플레이리스트를 랜덤 재생하면 항상 플레이리스트의 첫 곡이 처음으로 재생되는 버그 픽스
- 🐛 original 데이터가 초기화되는 버그 픽스 (이전 플리와 현재 플리의 length가 같으면 original 업데이트를 안 해줘서 그랬음)
- 🐛 #269 에서 실수로 지운 플레이어 플레이리스트 코드 복구
