### PR TITLE
:construction_worker: 맥 유니버셜 빌드 지원

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,27 +75,27 @@ jobs:
           echo "APPLE_PASSWORD=${{ secrets.APPLE_PASSWORD }}" >> $GITHUB_ENV
           echo "APPLE_TEAM_ID=${{ secrets.APPLE_TEAM_ID }}" >> $GITHUB_ENV
 
-      - name: Make application (x64)
+      - name: Make application (Windows)
+        if: matrix.os.image == 'windows-latest'
         run: yarn make --arch x64
 
-      - name: Make application (arm64)
+      - name: Make application (macOS)
         if: matrix.os.image == 'macos-latest'
-        run: yarn make --arch arm64
+        run: yarn make --arch universal
 
-      - name: Upload artifact (x64)
+      - name: Upload artifact (Windows)
+        if: matrix.os.image == 'windows-latest'
         uses: actions/upload-artifact@v3
         with:
-          name: 왁타버스 뮤직 ${{ matrix.os.name }} (x64)
+          name: 왁타버스 뮤직 ${{ matrix.os.name }}
           path: |
-            ./out/make/*-x64.dmg
-            ./out/make/zip/darwin/x64/*.zip
             ./out/make/zip/win32/x64/*.zip
 
-      - name: Upload artifact (arm64)
+      - name: Upload artifact (macOS)
         if: matrix.os.image == 'macos-latest'
         uses: actions/upload-artifact@v3
         with:
-          name: 왁타버스 뮤직 ${{ matrix.os.name }} (arm64)
+          name: 왁타버스 뮤직 ${{ matrix.os.name }} (macOS)
           path: |
-            ./out/make/*-arm64.dmg
-            ./out/make/zip/darwin/arm64/*.zip
+            ./out/make/*-universal.dmg
+            ./out/make/zip/darwin/universal/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
         if: matrix.os.image == 'macos-latest'
         uses: actions/upload-artifact@v3
         with:
-          name: 왁타버스 뮤직 ${{ matrix.os.name }} (macOS)
+          name: 왁타버스 뮤직 ${{ matrix.os.name }}
           path: |
             ./out/make/*-universal.dmg
             ./out/make/zip/darwin/universal/*.zip

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -6,21 +6,6 @@ import { join } from "path";
 
 dotenv.config();
 
-const availableArch = ["arm64", "x64"];
-const getTargetArch = (): string => {
-  for (const arg of process.argv) {
-    if (availableArch.includes(arg)) {
-      return arg;
-    }
-    const matches = arg.match(RegExp(`--arch=(${availableArch.join("|")})`));
-    if (matches !== null) {
-      return matches[1];
-    }
-  }
-
-  return process.arch;
-};
-
 const config: ForgeConfig = {
   packagerConfig: {
     name: "Wakmusic",
@@ -149,7 +134,7 @@ const config: ForgeConfig = {
           return [
             {
               type: "file",
-              path: `${process.cwd()}/out/Wakmusic-darwin-${getTargetArch()}/Wakmusic.app`,
+              path: `${process.cwd()}/out/Wakmusic-darwin-universal/Wakmusic.app`,
               x: 292,
               y: 290,
             },

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -45,9 +45,9 @@ if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
 }
 
 const server = "https://update.electronjs.org";
-const feed = `${server}/wakmusic/wakmusic-pc/${process.platform}-${
-  process.arch
-}/${app.getVersion()}`;
+const feed = `${server}/wakmusic/wakmusic-pc/${
+  process.platform
+}-universal/${app.getVersion()}`;
 
 autoUpdater.setFeedURL({
   url: feed,


### PR DESCRIPTION
## 개요

기존에 나눠져 있던 인텔 버전과 애플 실리콘 버전을 유니버셜 버전으로 통합했습니다

## 작업 내용

- 깃허브 액션에서 유니버셜 버전으로 빌드하도록 수정했습니다.
- MakerDMG가 유니버셜 파일을 가리키도록 수정했습니다.
- 자동 업데이트 시스템이 유니버셜 빌드를 가리키도록 수정했습니다.